### PR TITLE
edits to vignettes

### DIFF
--- a/R/estimate_predicted.R
+++ b/R/estimate_predicted.R
@@ -31,7 +31,7 @@
 #'
 #' # Bayesian models
 #' if (require("rstanarm")) {
-#'   model <- rstanarm::stan_glm(mpg ~ wt, data = mtcars, refresh=0)
+#'   model <- rstanarm::stan_glm(mpg ~ wt, data = mtcars, refresh = 0)
 #'   estimate_response(model)
 #'   estimate_relation(model)
 #' }
@@ -83,12 +83,13 @@ estimate_response <- estimate_prediction
 
   # Get predicted ----------------
   predictions <- insight::get_predicted(model,
-                                        data = data,
-                                        predict = predict,
-                                        ci = ci,
-                                        dispersion_function = "mad",
-                                        interval_function = "hdi",
-                                        ...)
+    data = data,
+    predict = predict,
+    ci = ci,
+    dispersion_function = "mad",
+    interval_function = "hdi",
+    ...
+  )
   out <- as.data.frame(predictions, keep_iterations = keep_iterations)
   out <- cbind(data, out)
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -20,6 +20,7 @@ codecov
 doi
 easystats
 emmeans
+favour
 fdr
 glmmTMB
 hochberg
@@ -29,6 +30,7 @@ joss
 loess
 modelisation
 nd
+polyvalent
 rootSolve
 se
 setosa

--- a/tests/testthat/test-estimate_predicted.R
+++ b/tests/testthat/test-estimate_predicted.R
@@ -8,8 +8,6 @@ osx <- tryCatch({
 })
 
 if (require("testthat") && require("modelbased") && require("gamm4") && require("rstanarm") && require("lme4") && require("glmmTMB") && require("mgcv") && require("MASS") && require("brms") && require("testthat")) {
-
-
   test_that("estimate_link", {
 
     # LMER4
@@ -31,7 +29,7 @@ if (require("testthat") && require("modelbased") && require("gamm4") && require(
 
     # GAMM4
     model <- gamm4::gamm4(Petal.Length ~ Petal.Width + s(Sepal.Length),
-                          random = ~ (1 | Species), data = iris
+      random = ~ (1 | Species), data = iris
     )
     expect_equal(nrow(modelbased::estimate_link(model, length = 3)), 9)
     expect_equal(dim(modelbased::estimate_link(model, include_smooth = FALSE, length = 3)), c(3, 5))
@@ -40,8 +38,8 @@ if (require("testthat") && require("modelbased") && require("gamm4") && require(
     if (!osx) {
       # STAN_GAMM4
       model <- suppressWarnings(rstanarm::stan_gamm4(Petal.Length ~ Petal.Width + s(Sepal.Length),
-                                                     random = ~ (1 | Species), data = iris,
-                                                     iter = 100, chains = 2, refresh = 0
+        random = ~ (1 | Species), data = iris,
+        iter = 100, chains = 2, refresh = 0
       ))
       expect_equal(nrow(modelbased::estimate_relation(model, length = 3)), 9)
       expect_equal(dim(modelbased::estimate_link(model, include_smooth = FALSE, length = 3)), c(3, 5))
@@ -52,38 +50,38 @@ if (require("testthat") && require("modelbased") && require("gamm4") && require(
 
 
 
-    test_that("estimate_response - Bayesian", {
-      model <- suppressWarnings(rstanarm::stan_glm(mpg ~ wt + poly(cyl, 2, raw = TRUE), data = mtcars, refresh = 0, iter = 200, chains = 2))
-      estim <- estimate_response(model, seed = 333)
-      expect_equal(nrow(estim), nrow(mtcars))
+  test_that("estimate_response - Bayesian", {
+    model <- suppressWarnings(rstanarm::stan_glm(mpg ~ wt + poly(cyl, 2, raw = TRUE), data = mtcars, refresh = 0, iter = 200, chains = 2))
+    estim <- estimate_response(model, seed = 333)
+    expect_equal(nrow(estim), nrow(mtcars))
 
-      model <- suppressWarnings(rstanarm::stan_glm(mpg ~ wt * as.factor(gear), data = mtcars, refresh = 0, iter = 200, chains = 2))
-      estim <- estimate_response(model, data = "grid", seed = 333)
-      expect_equal(c(nrow(estim), ncol(estim)), c(30, 6))
+    model <- suppressWarnings(rstanarm::stan_glm(mpg ~ wt * as.factor(gear), data = mtcars, refresh = 0, iter = 200, chains = 2))
+    estim <- estimate_response(model, data = "grid", seed = 333)
+    expect_equal(c(nrow(estim), ncol(estim)), c(30, 6))
 
-      model <- suppressWarnings(rstanarm::stan_glm(mpg ~ as.factor(gear) / wt, data = mtcars, refresh = 0, iter = 200, chains = 2))
-      estim <- estimate_response(model)
-      expect_equal(c(nrow(estim), ncol(estim)), c(32, 6))
+    model <- suppressWarnings(rstanarm::stan_glm(mpg ~ as.factor(gear) / wt, data = mtcars, refresh = 0, iter = 200, chains = 2))
+    estim <- estimate_response(model)
+    expect_equal(c(nrow(estim), ncol(estim)), c(32, 6))
 
-      model <- suppressWarnings(rstanarm::stan_glm(Sepal.Width ~ Petal.Width, data = iris, refresh = 0, iter = 200, chains = 2))
-      estim <- estimate_link(model, keep_iterations = TRUE)
-      draws <- bayestestR::reshape_iterations(estim)
-      expect_equal(c(nrow(draws), ncol(draws)), c(2000, 8))
+    model <- suppressWarnings(rstanarm::stan_glm(Sepal.Width ~ Petal.Width, data = iris, refresh = 0, iter = 200, chains = 2))
+    estim <- estimate_link(model, keep_iterations = TRUE)
+    draws <- bayestestR::reshape_iterations(estim)
+    expect_equal(c(nrow(draws), ncol(draws)), c(2000, 8))
 
-      # Polr
-      model <- suppressWarnings(rstanarm::stan_polr(Species ~ Petal.Width + Petal.Length, data = iris, refresh = 0, iter = 200, chains = 2, prior = rstanarm::R2(0.2, "mean")))
-      estim <- estimate_link(model, length = 6)
-      expect_equal(c(nrow(estim), ncol(estim)), c(36, 6))
+    # Polr
+    model <- suppressWarnings(rstanarm::stan_polr(Species ~ Petal.Width + Petal.Length, data = iris, refresh = 0, iter = 200, chains = 2, prior = rstanarm::R2(0.2, "mean")))
+    estim <- estimate_link(model, length = 6)
+    expect_equal(c(nrow(estim), ncol(estim)), c(36, 6))
 
-      # Non-sampling algorithms
-      model <- rstanarm::stan_glm(mpg ~ disp, data = mtcars, algorithm = "meanfield", refresh = 0)
-      estim <- estimate_link(model, keep_iterations = TRUE)
-      expect_equal(c(nrow(estim), ncol(estim)), c(10, 1005))
+    # Non-sampling algorithms
+    model <- rstanarm::stan_glm(mpg ~ disp, data = mtcars, algorithm = "meanfield", refresh = 0)
+    estim <- estimate_link(model, keep_iterations = TRUE)
+    expect_equal(c(nrow(estim), ncol(estim)), c(10, 1005))
 
-      # model <- brms::brm(mpg ~ drat, data = mtcars, algorithm = "meanfield", refresh=0)
-      # estim <- estimate_link(model, keep_iterations = TRUE)
-      # expect_equal(c(nrow(estim), ncol(estim)), c(25, 1004))
-    })
+    # model <- brms::brm(mpg ~ drat, data = mtcars, algorithm = "meanfield", refresh=0)
+    # estim <- estimate_link(model, keep_iterations = TRUE)
+    # expect_equal(c(nrow(estim), ncol(estim)), c(25, 1004))
+  })
 
 
   test_that("estimate_response - Frequentist", {
@@ -119,5 +117,4 @@ if (require("testthat") && require("modelbased") && require("gamm4") && require(
     # # TODO: why no CI?
     # expect_equal(c(nrow(estim), ncol(estim)), c(10, 1))
   })
-
 }

--- a/vignettes/estimate_contrasts.Rmd
+++ b/vignettes/estimate_contrasts.Rmd
@@ -15,10 +15,16 @@ editor_options:
 bibliography: bibliography.bib
 ---
 
-```{r message=FALSE, warning=FALSE, include=FALSE}
+```{r, include=FALSE}
 library(knitr)
 options(knitr.kable.NA = "")
-knitr::opts_chunk$set(comment = ">", dpi = 450)
+knitr::opts_chunk$set(
+  comment = ">",
+  message = FALSE,
+  warning = FALSE,
+  out.width = "100%",
+  dpi = 450
+)
 options(digits = 2)
 
 if (!requireNamespace("ggplot2", quietly = TRUE) ||
@@ -30,71 +36,69 @@ if (!requireNamespace("ggplot2", quietly = TRUE) ||
 set.seed(333)
 ```
 
-Warning: we will go **full Bayesian** in this vignette. If you're not familiar
-with the Bayesian framework, we recommend starting with [**this gentle
-introduction**](https://easystats.github.io/bayestestR/articles/bayestestR.html).
+**Warning**: We will go **full Bayesian** in this vignette!
+If you're not familiar
+with the Bayesian framework, we recommend starting with [**this gentle introduction**](https://easystats.github.io/bayestestR/articles/bayestestR.html).
 
 # Testing pairwise differences
 
-In the [**previous
-tutorial**](https://easystats.github.io/estimate/articles/estimate_means.html),
-we computed marginal at the 3 different `Species` levels from the
+In the [**previous tutorial**](https://easystats.github.io/estimate/articles/estimate_means.html),
+we computed marginal means at the 3 different `Species` levels from the
 [`iris`](https://en.wikipedia.org/wiki/Iris_flower_data_set) dataset. However,
 one might also want to **statistically test** the differences between each
 levels, which can be achieved through **contrast analysis**. Although the
-procedure is much more powerful, its aim is somehow analog to the ***post hoc***
-analysis (pretty much consisting of pairwise t-tests) heavily used in
-psychological science to palliate the uselessness of ANOVAs.
+procedure is much more powerful, its aim is analogous to the ***post hoc***
+analysis (pretty much consisting of pairwise *t*-tests), which are heavily
+utilized in behavioral sciences as a way to follow up on hypotheses about global
+differences tested by ANOVAs with more specific hypotheses about pairwise
+differences.
 
-Let's do that based on the simple model from the previous tutorial:
+Let's carry out contrast analysis on the simple model from the previous tutorial:
 
-```{r message=FALSE, warning=FALSE, eval=FALSE}
+```{r}
 library(ggplot2)
 library(see)
 library(rstanarm)
 library(modelbased)
 
-
-model <- stan_glm(Sepal.Width ~ Species, data = iris)
-means <- estimate_means(model)
-```
-```{r message=FALSE, warning=FALSE, echo=FALSE}
-library(ggplot2)
-library(see)
-library(rstanarm)
-library(modelbased)
-
+# you can ignore the `refresh` argument, it just prevents the function from printing
+# a few details to the console
 model <- stan_glm(Sepal.Width ~ Species, data = iris, refresh = 0)
 means <- estimate_means(model)
 ```
-```{r message=FALSE, warning=FALSE}
+
+```{r }
 ggplot(iris, aes(x = Species, y = Sepal.Width, fill = Species)) +
   geom_violin() +
   geom_jitter2(width = 0.05, alpha = 0.5) +
   geom_line(data = means, aes(y = Mean, group = 1), size = 1) +
-  geom_pointrange(data = means, aes(y = Mean, ymin = CI_low, ymax = CI_high), size = 1, color = "white") +
+  geom_pointrange(data = means, 
+                  aes(y = Mean, ymin = CI_low, ymax = CI_high),
+                  size = 1, 
+                  color = "white") +
   theme_modern()
 ```
 
 **Contrast analysis** can be achieved through the `estimate_contrasts`
 function:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 estimate_contrasts(model)
 ```
 
-As we can see here, all pairwise differences can be considered as significant.
+If you can recall your [Bayesian apprenticeship](https://easystats.github.io/bayestestR/articles/example1.html),
+we can conclude that all pairwise differences are statistically significant.
 
 # Complex model
 
 Again, as contrast analysis is based on marginal means, it can be applied to
 more complex models:
 
-```{r message=FALSE, warning=FALSE, eval=FALSE}
+```{r, eval=FALSE}
 model <- stan_glm(Sepal.Width ~ Species * Petal.Width, data = iris)
 estimate_contrasts(model)
 ```
-```{r message=FALSE, warning=FALSE, echo=FALSE}
+```{r, echo=FALSE}
 model <- stan_glm(Sepal.Width ~ Species * Petal.Width, data = iris, refresh = 0, iter = 1000, chains = 2)
 estimate_contrasts(model)
 ```
@@ -106,7 +110,7 @@ even changes sign).
 Note that we can plot simple contrast analysis through **lighthouse plots** with
 the help of the `see` package:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(see)
 
 plot(estimate_contrasts(model), estimate_means(model)) +
@@ -124,7 +128,7 @@ continuous variable. Based on the model above (including the interaction with
 `Petal.Width`), we will compute the contrasts at 100 equally-spaced points of
 `Petal.Width`, that we will then visualise.
 
-```{r message=FALSE, warning=FALSE, fig}
+```{r, fig}
 contrasts <- estimate_contrasts(model, modulate = "Petal.Width", length = 100)
 
 # Create a variable with the two levels concatenated
@@ -140,8 +144,11 @@ ggplot(contrasts, aes(x = Petal.Width, y = Difference)) +
 ```
 
 As we can see, the difference between *versicolor* and *virginica* increases as
-`Petal.Width` increases. In conclusion, contrast analysis is a powerful tool to
-interpret and understand statistical models.
+`Petal.Width` increases. 
+
+# Conclusion
+
+Contrast analysis can be a powerful tool to interpret and understand statistical
+models.
 
 # References
-

--- a/vignettes/estimate_means.Rmd
+++ b/vignettes/estimate_means.Rmd
@@ -15,10 +15,16 @@ editor_options:
 bibliography: bibliography.bib
 ---
 
-```{r message=FALSE, warning=FALSE, include=FALSE}
+```{r, include=FALSE}
 library(knitr)
 options(knitr.kable.NA = "")
-knitr::opts_chunk$set(comment = ">", dpi = 450)
+knitr::opts_chunk$set(
+  comment = ">",
+  message = FALSE,
+  warning = FALSE,
+  out.width = "100%",
+  dpi = 450
+)
 options(digits = 2)
 
 if (!requireNamespace("ggplot2", quietly = TRUE) ||
@@ -31,15 +37,16 @@ if (!requireNamespace("ggplot2", quietly = TRUE) ||
 set.seed(333)
 ```
 
-This vignette will introduce the concept of marginal means. Warning: we will go
-**full Bayesian**. If you're not familiar with the Bayesian framework, we
-recommend starting with [**this gentle
-introduction**](https://easystats.github.io/bayestestR/articles/bayestestR.html).
+This vignette will introduce the concept of **marginal means**. 
+
+**Warning**: We will go **full Bayesian**! 
+If you're not familiar with the Bayesian framework, we
+recommend starting with [**this gentle introduction**](https://easystats.github.io/bayestestR/articles/bayestestR.html).
 
 # Raw Means
 
 The [`iris`](https://en.wikipedia.org/wiki/Iris_flower_data_set) dataset,
-available in base R, contains observations of 3 types of iris flowers (the
+available in base `R`, contains observations of 3 types of *iris* flowers (the
 `Species` variable); *Setosa*, *Versicolor* and *Virginica*, for which different
 features were measured, such as the length and width of the sepals and petals.
 
@@ -50,7 +57,7 @@ of the 3 species**.
 We can compute the means very easily by grouping the observations by species,
 and then computing the mean and the SD:
 
-```{r message=FALSE, warning=FALSE}
+```{r}
 library(dplyr)
 
 iris %>%
@@ -63,7 +70,7 @@ iris %>%
 
 We can also provide a plot:
 
-```{r message=FALSE, warning=FALSE}
+```{r}
 library(ggplot2)
 library(see)
 
@@ -74,49 +81,55 @@ ggplot(iris, aes(x = Species, y = Sepal.Width, fill = Species)) +
 ```
 
 However, these **raw means** might be biased, as the number of observations in
-each group might be different. Moreover, there might some hidden covariance or
+each group might be different. Moreover, there might be some hidden covariance or
 mediation with other variables in the dataset, creating a "spurious" influence
-on the means. **How to take these things into account?**
+on the means. 
+
+**How can we take these influences into account while calculating means?**
 
 # Marginal Means
 
-Another way of analyzing the means is to actually statistically **model them**,
+Another way of analyzing the means is to actually **statistically model them**,
 rather than simply describe them as they appear in the data. For instance, we
 could fit a simple Bayesian linear regression modeling the relationship between
 `Species` and `Sepal.Width`.
 
-Marginal means are basically means extracted from a statistical model. Note that
-as we are in a Bayesian framework, we will report the **median** of the
-posterior distribution of the marginal means.
+Marginal means are basically means extracted from a statistical model, and
+represent average of response variable (here, `Sepal.Width`) for each level of
+predictor variable (here, `Species`). Note that as we are in a Bayesian
+framework, we will report the **median** of the posterior distribution of the
+marginal means.
 
-```{r message=FALSE, warning=FALSE, eval=FALSE}
+```{r}
+set.seed(123)
 library(rstanarm)
 library(modelbased)
 
-model <- stan_glm(Sepal.Width ~ Species, data = iris)
-means <- estimate_means(model)
-means
-```
-```{r message=FALSE, warning=FALSE, echo=FALSE}
-library(rstanarm)
-library(modelbased)
-
+# you can ignore the `refresh` argument, it just prevents the function from printing
+# a few details to the console
 model <- stan_glm(Sepal.Width ~ Species, data = iris, refresh = 0)
 means <- estimate_means(model)
 means
 ```
 
-We can now add these means, as well as the [**credible interval
-(CI)**](https://easystats.github.io/bayestestR/articles/credible_interval.html)
+Note that the means computed here are not that different than the raw means we
+created above. From which we can surmise that there are not many spurious
+influences that we need to worry about in the `iris` dataset. But this might not
+be the case for your dataset.
+
+We can now add these means, as well as the [**credible interval (CI)**](https://easystats.github.io/bayestestR/articles/credible_interval.html)
 representing the uncertainty of the estimation, as an overlay on the previous
 plot:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 ggplot(iris, aes(x = Species, y = Sepal.Width, fill = Species)) +
   geom_violin() +
   geom_jitter2(width = 0.05, alpha = 0.5) +
   geom_line(data = means, aes(y = Mean, group = 1), size = 1) +
-  geom_pointrange(data = means, aes(y = Mean, ymin = CI_low, ymax = CI_high), size = 1, color = "white") +
+  geom_pointrange(data = means, 
+                  aes(y = Mean, ymin = CI_low, ymax = CI_high), 
+                  size = 1, 
+                  color = "white") +
   theme_modern()
 ```
 
@@ -128,34 +141,48 @@ account the interaction with the other variables, `Petal.Length` and
 `Petal.Width`. The estimated means will be "adjusted" (or will take into
 account) for variations of these other components.
 
-```{r message=FALSE, warning=FALSE, eval=FALSE}
-model <- stan_glm(Sepal.Width ~ Species * Sepal.Length * Petal.Width, data = iris)
+```{r}
+model <- stan_glm(Sepal.Width ~ Species * Sepal.Length * Petal.Width, 
+                  data = iris, 
+                  refresh = 0, 
+                  iter = 1000,
+                  chains = 2)
 means_complex <- estimate_means(model)
-means_complex
-```
-```{r message=FALSE, warning=FALSE, echo=FALSE}
-model <- stan_glm(Sepal.Width ~ Species * Sepal.Length * Petal.Width, data = iris, refresh = 0, iter = 1000, chains = 2)
-means_complex <- estimate_means(model)
+
 means_complex
 ```
 
-```{r message=FALSE, warning=FALSE}
+Now let's plot the marginal means from the simple linear model (shown in white
+dots) we saw above and the marginal means from the more complex model (shown in
+yellow dots) next to each other, which should help us notice how the adjusted
+means change depending on the predictors.
+
+<!-- The following figure is really difficult to make sense of -->
+<!-- We need to think of a simpler way to visualize these -->
+
+```{r }
 ggplot(iris, aes(x = Species, y = Sepal.Width, fill = Species)) +
   geom_violin() +
   geom_jitter2(width = 0.05, alpha = 0.5) +
   geom_line(data = means, aes(y = Mean, group = 1), size = 1, alpha = 0.25) +
-  geom_pointrange(data = means, aes(y = Mean, ymin = CI_low, ymax = CI_high), size = 1, color = "white") +
+  geom_pointrange(data = means, 
+                  aes(y = Mean, ymin = CI_low, ymax = CI_high), 
+                  size = 1, 
+                  color = "white") +
   geom_line(data = means_complex, aes(y = Mean, group = 1), size = 1) +
-  geom_pointrange(data = means_complex, aes(y = Mean, ymin = CI_low, ymax = CI_high), size = 1, color = "yellow") +
+  geom_pointrange(data = means_complex,
+                  aes(y = Mean, ymin = CI_low, ymax = CI_high), 
+                  size = 1,
+                  color = "yellow") +
   theme_modern()
 ```
 
-That's interesting: it seems that when adjusting the model for petal
-characteristics, the differences between Species seems to be even bigger!
+That's interesting! It seems that after adjusting the model for petal
+characteristics, the differences between `Species` seems to be even bigger!
 
-**But are these differences "significant"?** Click [here to read the tutorial on
-**contrast
+**But are these differences "significant"?** 
+
+That's where the contrast analysis comes into play! Click [here to read the tutorial on **contrast
 analysis**](https://easystats.github.io/estimate/articles/contrast_analysis.html).
 
 # References
-

--- a/vignettes/visualisation_matrix.Rmd
+++ b/vignettes/visualisation_matrix.Rmd
@@ -15,10 +15,16 @@ editor_options:
 bibliography: bibliography.bib
 ---
 
-```{r message=FALSE, warning=FALSE, include=FALSE}
+```{r, include=FALSE}
 library(knitr)
 options(knitr.kable.NA = "")
-knitr::opts_chunk$set(comment = ">", dpi = 450)
+knitr::opts_chunk$set(
+  comment = ">",
+  message = FALSE,
+  warning = FALSE,
+  out.width = "100%",
+  dpi = 450
+)
 options(digits = 2)
 
 if (!requireNamespace("parameters", quietly = TRUE) ||
@@ -47,7 +53,7 @@ represent and understand them.
 For instance, let's fit a simple linear model that models the relationship
 between `Sepal.Width` and `Sepal.Length`.
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(parameters)
 
 model <- lm(Sepal.Width ~ Sepal.Length, data = iris)
@@ -57,7 +63,7 @@ model_parameters(model)
 The most obvious way of representing this model is to plot the data points and
 add the regression line using the `geom_smooth` function from `ggplot2`:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(ggplot2)
 library(see)
 
@@ -74,7 +80,7 @@ create the regression line.
 
 Let's try the `visualisation_matrix` function from the `estimate` package.
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(modelbased)
 
 visualisation_matrix(iris["Sepal.Length"])
@@ -86,7 +92,7 @@ maximum, than the original data). The default **length** is 10, but we can
 adjust that through the `length` argument. Let's generate predictions using this
 reference grid of the predictor.
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 newdata <- visualisation_matrix(iris["Sepal.Length"], length = 5)
 newdata$Predicted_Sepal.Width <- predict(model, newdata)
 newdata
@@ -95,7 +101,7 @@ newdata
 Now that we have our *x* and *y* values, we can plot the line as an overlay to
 the actual data points:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width)) +
   geom_point() +
   geom_line(data = newdata, aes(y = Predicted_Sepal.Width), size = 1, color = "red") +
@@ -108,13 +114,12 @@ useful?
 # Mixed models
 
 Data grids are useful to represent more complex models. For instance, in the
-models above, the negative relationship between the length and width of the
+models above, the **negative** relationship between the length and width of the
 sepals is in fact biased by the presence of three different species. One way of
-adjusting the model for this grouping structure is to add it as a **random
-effect** in a **mixed model**. In the model below, the "fixed" effects (the
-parameters of interest) will be adjusted ("averaged over") the random effects.
+adjusting the model for this grouping structure is to add it as a **random effect** in a **mixed model**. In the model below, the "fixed" effects (the
+parameters of interest) will be adjusted ("averaged over") to the random effects.
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(lme4)
 
 model <- lmer(Sepal.Width ~ Sepal.Length + (1 | Species), data = iris)
@@ -122,11 +127,13 @@ model_parameters(model)
 ```
 
 As we can see, when adjusting for the species, the relationship between the two
-variables **has become positive**! We can represent it using the same procedure
-as above (note the `re.form = NA` in the `predict` function to say that the
-random variable is not present in the new dataset).
+variables **has become positive**! 
 
-```{r message=FALSE, warning=FALSE}
+We can represent it using the same procedure as above (note the `re.form = NA`
+in the `predict` function to say that the random variable is not present in the
+new dataset).
+
+```{r }
 newdata <- visualisation_matrix(iris["Sepal.Length"], length = 5)
 newdata$Predicted_Sepal.Width <- predict(model, newdata, re.form = NA)
 
@@ -141,20 +148,19 @@ ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width)) +
 The above way of constructing the reference grid, i.e., by providing a single
 column of data to the function, is almost equivalent to the following:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 newdata <- visualisation_matrix(iris, target = "Sepal.Length", length = 5)
 newdata
 ```
 
 However, the other variables (present in the dataframe but not selected as
-`target`) have been "fixed", *i.e.*, maintained at some values. This is useful
-when we have other variables in the model which effect we are not interested
-in.
+`target`) are "fixed", *i.e.*, they are maintained at specific values. This is
+useful when we have other variables in the model in whose effect we are not
+interested.
 
-By default, **factors** are fixed by their **"reference" level** and **numeric
-variables** are fixed at their **mean**. However, this can be easily changed:
+By default, **factors** are fixed by their **"reference" level** and **numeric variables** are fixed at their **mean**. However, this can be easily changed:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 newdata <- visualisation_matrix(iris, target = "Sepal.Length", numerics = "min")
 newdata
 ```
@@ -168,21 +174,21 @@ factor.
 
 Let's visualise the regression line for each of the levels of `Species`:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 model <- lm(Sepal.Width ~ Sepal.Length * Species, data = iris)
 ```
-```{r message=FALSE, warning=FALSE, eval=FALSE}
+```{r, eval=FALSE}
 newdata <- visualisation_matrix(iris, target = c("Sepal.Length", "Species"), length = 5)
 newdata$Predicted_Sepal.Width <- predict(model, newdata)
 newdata
 ```
-```{r message=FALSE, warning=FALSE, echo=FALSE}
+```{r, echo=FALSE}
 newdata <- visualisation_matrix(iris, target = c("Sepal.Length", "Species"), length = 5)
 newdata$Predicted_Sepal.Width <- predict(model, newdata)
 newdata$Petal.Length <- NULL
 newdata
 ```
-```{r message=FALSE, warning=FALSE}
+```{r }
 ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Species)) +
   geom_point() +
   geom_line(data = newdata, aes(y = Predicted_Sepal.Width), size = 1) +
@@ -197,8 +203,13 @@ line**. The `preserve_range` option allows to remove observations that are
 "outside" the original dataset (however, the length should be increased to
 improve the precision toward the edges):
 
-```{r message=FALSE, warning=FALSE}
-newdata <- visualisation_matrix(iris, target = c("Sepal.Length", "Species"), length = 100, preserve_range = TRUE)
+```{r }
+newdata <- visualisation_matrix(iris,
+  target = c("Sepal.Length", "Species"),
+  length = 100,
+  preserve_range = TRUE
+)
+
 newdata$Predicted_Sepal.Width <- predict(model, newdata)
 
 ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Species)) +
@@ -209,24 +220,24 @@ ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Species)) +
 
 # Visualising an interaction between two numeric variables (three-way interaction)
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 model <- lm(Sepal.Length ~ Petal.Length * Petal.Width, data = iris)
 model_parameters(model)
 ```
 
 This idea can also be used to visualise interactions between two numeric
-variables, **aka the nightmare of every psychologist**. One possibility is to
+variables, **aka the nightmare of every scientist**. One possibility is to
 basically represent the relationship between the response and one predictor **at
 a few representative values of the second predictor**.
 
 In this case, we will represent the regression line between `Sepal.Length` and
-`Petal.Length` and a 5 equally spaced values of `Petal.Length`, to get a feel of
+`Petal.Length` and a 5 equally spaced values of `Petal.Length`, to get a feel for
 the interaction.
 
 We can obtain the right reference grid quite easily by chaining two
 `visualisation_matrix` together as follows:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(dplyr)
 
 newdata <- iris %>%
@@ -243,7 +254,7 @@ using `numerics = "combination"`.
 
 We can then visualise it as follows:
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 newdata$Predicted_Sepal.Length <- predict(model, newdata)
 
 iris %>%
@@ -257,10 +268,16 @@ iris %>%
 Such plot can be more clear by expressing the interaction variable in terms of
 deviations from the mean (as a standardized variable).
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 newdata <- iris %>%
   visualisation_matrix(c("Petal.Length", "Petal.Width"), length = 10) %>%
-  visualisation_matrix("Petal.Width", length = 3, numerics = "combination", standardize = TRUE, reference = iris)
+  visualisation_matrix("Petal.Width",
+    length = 3,
+    numerics = "combination",
+    standardize = TRUE,
+    reference = iris
+  )
+
 newdata$Predicted_Sepal.Length <- predict(model, newdata)
 
 
@@ -283,25 +300,36 @@ we'll leave discussing the meaningfulness of your models to you :)**
 
 # Tips and Tricks
 
-## visualization_matrix() also runs directly on models 
+## `visualization_matrix()` also runs directly on model objects 
 
-Let's take the following example of a **general additive mixed model (GAMM)**,
-in which are specified a **smooth term** (a non-linear relationship) and some
-**random factor**. One can directly extract the visualization matrix by running
-the function on it:
+To illustrate this, let's set up a **general additive mixed model (GAMM)**,
+where we are going to specify a **smooth term** (a non-linear relationship;
+specified by `s()` function) and some **random effects** structure. 
 
-```{r message=FALSE, warning=FALSE}
+```{r }
 library(gamm4)
 
-model <- gamm4::gamm4(Petal.Length ~ Petal.Width + s(Sepal.Length), random = ~ (1 | Species), data = iris)
-
-newdata <- visualisation_matrix(model, length = 3, include_random = FALSE)
-newdata
+model <- gamm4::gamm4(
+  formula = Petal.Length ~ Petal.Width + s(Sepal.Length),
+  random = ~ (1 | Species),
+  data = iris
+)
 ```
 
-One can also skip the smooth term if the only interest are the fixed effects:
+One can directly extract the visualization matrix for this model by entering the entire object into the function:
 
-```{r message=FALSE, warning=FALSE}
+```{r}
+visualisation_matrix(model, length = 3, include_random = FALSE)
+```
+
+We also skip the smooth term if we are interested only in the fixed effects:
+
+```{r }
 visualisation_matrix(model, length = 3, include_random = FALSE, include_smooth = FALSE)
 ```
 
+We can also include random effects:
+
+```{r }
+visualisation_matrix(model, length = 3, include_random = TRUE)
+```


### PR DESCRIPTION
I am wondering if we should be changing the `iris` examples with `palmerpenguins` examples. 

The `penguins` dataset has much more variability and more challenging aspects to it than the `iris` dataset. Agree that we will have to add this package to `Suggests` but I think that shouldn't be a problem for us.