### PR TITLE
DESCRIPTION: Remotes: Add missing comma

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Suggests:
     testthat,
     spelling
 Remotes: 
-    easystats/bayestestR
+    easystats/bayestestR,
     easystats/see
 Encoding: UTF-8
 RoxygenNote: 7.1.1.9001


### PR DESCRIPTION
This fixes the following error:
```r
Error: Error: Missing commas separating Remotes: 'easystats/bayestestR
    easystats/see'
```