### PR TITLE
Fix GHA with Ubuntu

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,7 @@ jobs:
           use-public-rspm: true
 
       - name: Install GSL on Ubuntu
-        if: runner.os == 'ubuntu'
+        if: runner.os == 'Linux'
         run: |
           sudo add-apt-repository ppa:dns/gnu
           sudo apt-get update


### PR DESCRIPTION
Related to #192. GSL deps weren't installed for Ubuntu, which created errors later during the package installation.

Possible values for `runner.os` are "Linux", "Windows" or "macOS" (see [here](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context)).