### PR TITLE
fix: transform and adjust have no effect in estimate_contrast.R

### DIFF
--- a/R/estimate_contrasts.R
+++ b/R/estimate_contrasts.R
@@ -85,8 +85,9 @@ estimate_contrasts <- function(model,
     contrast = contrast,
     at = at,
     fixed = fixed,
-    transform = "none",
+    transform = transform,
     method = method,
+    adjust = adjust,
     ...
   )
 


### PR DESCRIPTION
The `transform` parameter has no effect because it is set to `"none"` in `get_emcontrasts`.

The `adjust` parameter has no effect on the p-values because this parameter is not passed to `get_emcontrasts`.

This PR corrects that.