### PR TITLE
marginaleffects 0.17.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.8.6.4
+Version: 0.8.6.5
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/R/get_marginaleffects.R
+++ b/R/get_marginaleffects.R
@@ -41,7 +41,7 @@ get_marginaleffects <- function(model,
   if (length(fixed) == 0) fixed <- NULL
 
   # Compute stuff
-  estimated <- marginaleffects::marginaleffects(model, variables = trend, newdata = newdata, ...)
+  estimated <- marginaleffects::slopes(model, variables = trend, newdata = newdata, ...)
 
   attr(estimated, "trend") <- trend
   attr(estimated, "at") <- at


### PR DESCRIPTION
The `marginaleffects` function was renamed `slopes` a while ago. It will be hard deprecated in the near future.