### PR TITLE
Check which dev-package are required

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     effectsize (>= 0.8.8),
     insight (>= 0.20.0),
     parameters (>= 0.21.7),
-    performance (>= 0.11.0),
+    performance (>= 0.12.0),
     graphics,
     stats,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,9 +35,9 @@ Depends:
     R (>= 3.6)
 Imports:
     bayestestR (>= 0.13.2),
-    datawizard (>= 0.10.0),
+    datawizard (>= 0.11.0),
     effectsize (>= 0.8.8),
-    insight (>= 0.19.11),
+    insight (>= 0.20.0),
     parameters (>= 0.21.7),
     performance (>= 0.11.0),
     graphics,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.8.7.1
+Version: 0.8.7.2
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.8.7.2
+Version: 0.8.7.3
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,4 +77,3 @@ Config/Needs/website:
     rstudio/bslib,
     r-lib/pkgdown,
     easystats/easystatstemplate
-Remotes: easystats/insight, easystats/datawizard, easystats/parameters, easystats/performance

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,7 +73,4 @@ RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Roxygen: list(markdown = TRUE)
-Config/Needs/website:
-    rstudio/bslib,
-    r-lib/pkgdown,
-    easystats/easystatstemplate
+Config/Needs/website: easystats/easystatstemplate


### PR DESCRIPTION
_insight_ is on CRAN and breaks _modelbased_. This PR removes all dev-packages from the REMOTES field, to check which of those packages are required to be on CRAN first, before we submit _modelbased_.