### PR TITLE
Fix custom hypothesis

### DIFF
--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -102,6 +102,7 @@ get_marginalcontrasts <- function(model,
 
 .is_custom_comparison <- function(comparison) {
   !is.null(comparison) &&
+    length(comparison) == 1 &&
     is.character(comparison) &&
     grepl("=", comparison, fixed = TRUE) &&
     grepl("\\bb\\d+\\b", comparison)

--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -124,12 +124,26 @@ get_marginalcontrasts <- function(model,
   # this is the row-order we use in modelbased
   datagrid$.rowid <- 1:nrow(datagrid)
   # this is the row-order in marginaleffects
-  datawizard::data_arrange(datagrid, colnames(datagrid)[1:(length(datagrid) - 1)])
+  datagrid <- datawizard::data_arrange(datagrid, colnames(datagrid)[1:(length(datagrid) - 1)])
   # we need to extract all b's
   b <- .extract_custom_comparison(comparison)
-  new_b <- paste0("b", datagrid$.rowid[as.numeric(gsub("b", "", b, fixed = TRUE))])
+  # these are the new numbers of the b-values
+  new_b_numbers <- datagrid$.rowid[as.numeric(gsub("b", "", b, fixed = TRUE))]
+  new_b <- paste0("b", new_b_numbers)
+  # we need to replace all occurences of "b" in comparison with "new_b".
+  # however, to avoid overwriting already replaced values with "gsub()", we
+  # first replace with a non-existing pattern "new_b_letters", which we will
+  # replace with "new_b" in a second step
+  new_b_letters <- paste0("b", letters[new_b_numbers])
 
-  ## TODO: we need to replace all occurences of "b" in comparuson with new_b
+  # first, numbers to letters
+  for (i in seq_along(b)) {
+    comparison <- gsub(b[i], new_b_letters[i], comparison, fixed = TRUE)
+  }
+  # next, letters to new numbers
+  for (i in seq_along(b)) {
+    comparison <- gsub(new_b_letters[i], new_b[i], comparison, fixed = TRUE)
+  }
 
   comparison
 }

--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -128,10 +128,11 @@ get_marginalcontrasts <- function(model,
     datagrid$.rowid <- 1:nrow(datagrid)
     # this is the row-order in marginaleffects
     datagrid <- datawizard::data_arrange(datagrid, colnames(datagrid)[1:(length(datagrid) - 1)])
-    # we need to extract all b's
+    # we need to extract all b's and the former parameter numbers
     b <- .extract_custom_comparison(comparison)
+    old_b_numbers <- as.numeric(gsub("b", "", b, fixed = TRUE))
     # these are the new numbers of the b-values
-    new_b_numbers <- datagrid$.rowid[as.numeric(gsub("b", "", b, fixed = TRUE))]
+    new_b_numbers <- match(old_b_numbers, datagrid$.rowid)
     new_b <- paste0("b", new_b_numbers)
     # we need to replace all occurences of "b" in comparison with "new_b".
     # however, to avoid overwriting already replaced values with "gsub()", we

--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -121,30 +121,31 @@ get_marginalcontrasts <- function(model,
 
 
 .reorder_custom_hypothesis <- function(comparison, datagrid) {
-  # this is the row-order we use in modelbased
-  datagrid$.rowid <- 1:nrow(datagrid)
-  # this is the row-order in marginaleffects
-  datagrid <- datawizard::data_arrange(datagrid, colnames(datagrid)[1:(length(datagrid) - 1)])
-  # we need to extract all b's
-  b <- .extract_custom_comparison(comparison)
-  # these are the new numbers of the b-values
-  new_b_numbers <- datagrid$.rowid[as.numeric(gsub("b", "", b, fixed = TRUE))]
-  new_b <- paste0("b", new_b_numbers)
-  # we need to replace all occurences of "b" in comparison with "new_b".
-  # however, to avoid overwriting already replaced values with "gsub()", we
-  # first replace with a non-existing pattern "new_b_letters", which we will
-  # replace with "new_b" in a second step
-  new_b_letters <- paste0("b", letters[new_b_numbers])
-
-  # first, numbers to letters
-  for (i in seq_along(b)) {
-    comparison <- gsub(b[i], new_b_letters[i], comparison, fixed = TRUE)
+  # only proceed if we have a custom hypothesis
+  if (.is_custom_comparison(comparison)) {
+    # this is the row-order we use in modelbased
+    datagrid$.rowid <- 1:nrow(datagrid)
+    # this is the row-order in marginaleffects
+    datagrid <- datawizard::data_arrange(datagrid, colnames(datagrid)[1:(length(datagrid) - 1)])
+    # we need to extract all b's
+    b <- .extract_custom_comparison(comparison)
+    # these are the new numbers of the b-values
+    new_b_numbers <- datagrid$.rowid[as.numeric(gsub("b", "", b, fixed = TRUE))]
+    new_b <- paste0("b", new_b_numbers)
+    # we need to replace all occurences of "b" in comparison with "new_b".
+    # however, to avoid overwriting already replaced values with "gsub()", we
+    # first replace with a non-existing pattern "new_b_letters", which we will
+    # replace with "new_b" in a second step
+    new_b_letters <- paste0("b", letters[new_b_numbers])
+    # first, numbers to letters
+    for (i in seq_along(b)) {
+      comparison <- gsub(b[i], new_b_letters[i], comparison, fixed = TRUE)
+    }
+    # next, letters to new numbers
+    for (i in seq_along(b)) {
+      comparison <- gsub(new_b_letters[i], new_b[i], comparison, fixed = TRUE)
+    }
   }
-  # next, letters to new numbers
-  for (i in seq_along(b)) {
-    comparison <- gsub(new_b_letters[i], new_b[i], comparison, fixed = TRUE)
-  }
-
   comparison
 }
 

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -124,6 +124,9 @@ get_marginalmeans <- function(model,
     fun_args$type <- predict
   }
 
+  # =========================================================================
+  # only needed to estimate_contrasts() with custom hypothesis ==============
+  # =========================================================================
   # for custom hypothesis, like "b2=b5" or "(b2-b1)=(b4-b3)", we need to renumber
   # the b-values internally, because we have a different sorting in our output
   # compared to what "avg_predictions()" returns... so let's check if we have to
@@ -154,6 +157,13 @@ get_marginalmeans <- function(model,
   # just need to add "hypothesis" argument
   means <- suppressWarnings(do.call(marginaleffects::avg_predictions, fun_args))
 
+  # =========================================================================
+  # only needed to estimate_contrasts() with custom hypothesis ==============
+  # =========================================================================
+  # fix term label for custom hypothesis
+  if (.is_custom_comparison(comparison)) {
+    means$term <- gsub(" ", "", comparison, fixed = TRUE)
+  }
 
   # Last step: Save information in attributes  --------------------------------
   # ---------------------------------------------------------------------------

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -30,6 +30,7 @@ get_marginalmeans <- function(model,
   # check if available
   insight::check_if_installed("marginaleffects")
   dots <- list(...)
+  comparison <- dots$hypothesis
 
   ## TODO: remove deprecation warning later
   if (!is.null(transform)) {
@@ -127,9 +128,13 @@ get_marginalmeans <- function(model,
   # the b-values internally, because we have a different sorting in our output
   # compared to what "avg_predictions()" returns... so let's check if we have to
   # take care of this
-  comparison <- dots$hypothesis
   if (!is.null(comparison)) {
-    dots$hypothesis <- .reorder_custom_hypothesis(comparison, datagrid)
+    # create a data frame with the same sorting as the data grid, but only
+    # for the focal terms
+    custom_grid <- data.frame(expand.grid(
+      lapply(datagrid[datagrid_info$at_specs$varname], unique)
+    ))
+    dots$hypothesis <- .reorder_custom_hypothesis(comparison, custom_grid)
   }
 
   # cleanup

--- a/R/table_footer.R
+++ b/R/table_footer.R
@@ -97,11 +97,11 @@
     # and combine column names with row values
     if (!is.null(datagrid)) {
       # transpose, so we can easier extract information
-      transposed_dg <- t(datagrid)
+      transposed_dg <- t(datagrid[info$focal_terms])
       # interate over all parameters and create labels with proper names
       hypothesis_labels <- unlist(lapply(parameter_names, function(i) {
         rows <- as.numeric(sub(".", "", i))
-        paste0(i, " = ", toString(paste0(colnames(datagrid), " [", transposed_dg[, rows], "]")))
+        paste0(i, " = ", toString(paste0(info$focal_terms, " [", transposed_dg[, rows], "]")))
       }), use.names = FALSE)
       # add all names to the footer
       table_footer <- paste0(

--- a/tests/testthat/_snaps/estimate_contrasts.md
+++ b/tests/testthat/_snaps/estimate_contrasts.md
@@ -59,19 +59,19 @@
     Output
       Marginal Contrasts Analysis
       
-      Parameter       | Difference |   SE |          95% CI | t(113) |     p
-      ----------------------------------------------------------------------
-      (b2-b1)=(b4-b3) |      -7.71 | 2.82 | [-13.30, -2.12] |  -2.73 | 0.007
+      Parameter       | Difference |   SE |        95% CI | t(113) |     p
+      --------------------------------------------------------------------
+      (b2-b1)=(b4-b3) |       5.78 | 2.82 | [0.20, 11.37] |   2.05 | 0.043
       
       Variable predicted: alertness
       Predictors contrasted: time, coffee
       Predictors averaged: sex
       p-values are uncorrected.
       Parameters:
-      b2 = time [noon], coffee [coffee], sex [male]
-      b1 = time [morning], coffee [coffee], sex [male]
-      b4 = time [morning], coffee [control], sex [male]
-      b3 = time [afternoon], coffee [coffee], sex [male]
+      b2 = time [noon], coffee [coffee]
+      b1 = time [morning], coffee [coffee]
+      b4 = time [morning], coffee [control]
+      b3 = time [afternoon], coffee [coffee]
 
 ---
 

--- a/tests/testthat/_snaps/estimate_contrasts.md
+++ b/tests/testthat/_snaps/estimate_contrasts.md
@@ -76,6 +76,26 @@
 ---
 
     Code
+      print(estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects",
+      p_adjust = "none", comparison = "b5=b3"), zap_small = TRUE, table_width = Inf)
+    Output
+      Marginal Contrasts Analysis
+      
+      Parameter | Difference |   SE |        95% CI | t(113) |     p
+      --------------------------------------------------------------
+      b5=b3     |      -1.93 | 1.99 | [-5.88, 2.02] |  -0.97 | 0.336
+      
+      Variable predicted: alertness
+      Predictors contrasted: time, coffee
+      Predictors averaged: sex
+      p-values are uncorrected.
+      Parameters:
+      b5 = time [noon], coffee [control]
+      b3 = time [afternoon], coffee [coffee]
+
+---
+
+    Code
       estimate_contrasts(model, backend = "emmeans")
     Message
       No variable was specified for contrast estimation. Selecting `contrast =

--- a/tests/testthat/test-estimate_contrasts.R
+++ b/tests/testthat/test-estimate_contrasts.R
@@ -277,6 +277,7 @@ test_that("estimate_contrasts - marginaleffects", {
   out1 <- estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = "b5=b3")
   out2 <- ggeffects::test_predictions(m, c("time", "coffee"), test = "b5=b3")
   expect_equal(out1$Difference, out2$Contrast, tolerance = 1e-4)
+  expect_snapshot(print(estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = "b5=b3"), zap_small = TRUE, table_width = Inf)) # nolint
 })
 
 

--- a/tests/testthat/test-estimate_contrasts.R
+++ b/tests/testthat/test-estimate_contrasts.R
@@ -265,11 +265,18 @@ test_that("estimate_contrasts - dfs", {
 test_that("estimate_contrasts - marginaleffects", {
   ## TODO: skip for marginaleffects 0.24.0?
   skip_if_not_installed("Formula")
+  skip_if_not_installed("ggeffects")
   data(coffee_data, package = "ggeffects")
   m <- lm(alertness ~ time * coffee + sex, data = coffee_data)
   expect_snapshot(print(estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none"), zap_small = TRUE, table_width = Inf)) # nolint
   expect_snapshot(print(estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = ratio ~ reference | coffee), zap_small = TRUE, table_width = Inf)) # nolint
   expect_snapshot(print(estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = "(b2-b1)=(b4-b3)"), zap_small = TRUE, table_width = Inf)) # nolint
+  out1 <- estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = "(b2-b1)=(b4-b3)")
+  out2 <- ggeffects::test_predictions(m, c("time", "coffee"), test = "(b2-b1)=(b4-b3)")
+  expect_equal(out1$Difference, out2$Contrast, tolerance = 1e-4)
+  out1 <- estimate_contrasts(m, c("time", "coffee"), backend = "marginaleffects", p_adjust = "none", comparison = "b5=b3")
+  out2 <- ggeffects::test_predictions(m, c("time", "coffee"), test = "b5=b3")
+  expect_equal(out1$Difference, out2$Contrast, tolerance = 1e-4)
 })
 
 


### PR DESCRIPTION
```r
library(modelbased)
library(ggeffects)

set.seed(123)
n <- 200
d <- data.frame(
  outcome = rnorm(n),
  grp = as.factor(sample(c("treatment", "control"), n, TRUE)),
  episode = as.factor(sample(1:3, n, TRUE)),
  sex = as.factor(sample(c("female", "male"), n, TRUE, prob = c(0.4, 0.6)))
)
model2 <- lm(outcome ~ grp * episode, data = d)
estimate_contrasts(model2, c("episode", "grp"), comparison = "b2 = b5", backend = "marginaleffects")
```

should match

```r
# compute specific contrast directly
test_predictions(model2, c("episode", "grp"), test = "b2 = b5")
#> Hypothesis | Contrast |      95% CI |     p
#> -------------------------------------------
#> b2=b5      |     0.06 | -0.41, 0.52 | 0.816
#> 
#> Tested hypothesis: episode[2],grp[control] = episode[2],grp[treatment]
```

- [x] add tests
- [ ] test against other examples in https://strengejacke.github.io/ggeffects/articles/introduction_comparisons_1.html