### PR TITLE
Treat integer-numerics with few levels as categorical for contrasts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.9.0.35
+Version: 0.9.0.36
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -67,8 +67,9 @@ get_marginalcontrasts <- function(model,
   # Second step: compute contrasts, for slopes or categorical -----------------
   # ---------------------------------------------------------------------------
 
-  # if first focal term is numeric, we contrast slopes
-  if (is.numeric(model_data[[first_focal]]) && !first_focal %in% on_the_fly_factors) {
+  # if first focal term is numeric, we contrast slopes, but slopes only for
+  # # numerics with many values, not for binary or likert-alike
+  if (is.numeric(model_data[[first_focal]]) && !.is_likert(model_data[[first_focal]]) && !first_focal %in% on_the_fly_factors) { # nolint
     # sanity check - contrast for slopes only makes sense when we have a "by" argument
     if (is.null(my_args$by)) {
       insight::format_error("Please specify the `by` argument to calculate contrasts of slopes.") # nolint

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,27 @@
     tryCatch(code, error = function(e) on_error)
   }
 }
+
+
+#' @keywords internal
+#' @noRd
+.is_integer <- function(x) {
+  tryCatch(
+    expr = {
+      ifelse(is.infinite(x), FALSE, x %% 1 == 0)
+    },
+    warning = function(w) {
+      is.integer(x)
+    },
+    error = function(e) {
+      FALSE
+    }
+  )
+}
+
+
+#' @keywords internal
+#' @noRd
+.is_likert <- function(x, n_uniques = 5) {
+  all(.is_integer(x)) && insight::n_unique(x) <= n_uniques
+}

--- a/tests/testthat/test-estimate_contrasts.R
+++ b/tests/testthat/test-estimate_contrasts.R
@@ -897,3 +897,19 @@ test_that("estimate_contrast, filterin in `by` and `contrast`", {
   out <- estimate_contrasts(m, "e42dep", by = "c172code=c('low','mid')")
   expect_identical(dim(out), c(12L, 10L))
 })
+
+
+test_that("estimate_contrast, don't calculate slopes for integers", {
+  data(mtcars)
+  m <- lm(mpg ~ hp + gear, data = mtcars)
+  expect_silent(estimate_contrasts(m, "gear"))
+  out <- estimate_contrasts(m, "gear")
+  expect_identical(dim(out), c(3L, 9L))
+
+  expect_error(
+    estimate_contrasts(m, "hp"),
+    regex = "Please specify"
+  )
+  out <- estimate_contrasts(m, "hp", by = "gear")
+  expect_identical(dim(out), c(3L, 8L))
+})


### PR DESCRIPTION
Formerly, code like

```r
m <- lm(mpg ~ hp + gear, data = mtcars)
modelbased::estimate_contrasts(m, "gear")
```

didn't work, because `gear` is numeric. You had to convert to factor first. But usually, a variable with 2 or three values is most likely not considered as numeric.