### PR TITLE
Understanding the “standard errors are probably not reliable” warning message when fitting mixed models via lme4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.12.0.11
+Version: 0.12.0.12
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,10 @@
 
 * Improved documentation and improved informative messages.
 
+* Message about unreliable standard errors (for certain models, when predicting
+  random effects) was removed for now, because it is not sure if standard errors
+  were unreliable at all.
+
 ## Bug fixes
 
 * Fixed issue with `by` in `estimate_contrasts()` when `comparison` was

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,12 +72,15 @@
       msg <- c(msg, insight::color_text(code_snippet, "green"), "\n")
     }
     message(msg)
-  } else if (length(out$SE) > 1 && isTRUE(all(out$SE == out$SE[1])) && insight::is_mixed_model(model)) {
-    msg <- "Standard errors are probably not reliable. This can happen when random effects are involved. You may try `estimate_relation()` instead." # nolint
-    if (!inherits(model, "glmmTMB")) {
-      msg <- paste(msg, "You may also try package {.pkg glmmTMB} to produce valid standard errors.")
-    }
-    insight::format_alert(msg)
+
+    # disable message for now, see
+    # https://github.com/easystats/modelbased/issues/526
+    # } else if (length(out$SE) > 1 && isTRUE(all(out$SE == out$SE[1])) && insight::is_mixed_model(model)) {
+    #   msg <- "Standard errors are probably not reliable. This can happen when random effects are involved. You may try `estimate_relation()` instead." # nolint
+    #   if (!inherits(model, "glmmTMB")) {
+    #     msg <- paste(msg, "You may also try package {.pkg glmmTMB} to produce valid standard errors.")
+    #   }
+    #   insight::format_alert(msg)
   }
 }
 

--- a/tests/testthat/test-estimate_contrasts_methods.R
+++ b/tests/testthat/test-estimate_contrasts_methods.R
@@ -173,11 +173,10 @@ test_that("estimate_contrasts - random effects, single by/contrast", {
     estimate_contrasts(model, contrast = "gear"),
     regex = "Could not calculate"
   )
-  expect_message(
+  expect_silent(
     {
       estim <- estimate_relation(model, by = "gear")
-    },
-    regex = "Standard errors are probably not reliable"
+    }
   )
   out <- estimate_contrasts(estim, contrast = "gear")
   expect_identical(dim(out), c(3L, 8L))

--- a/tests/testthat/test-estimate_means_mixed.R
+++ b/tests/testthat/test-estimate_means_mixed.R
@@ -108,9 +108,8 @@ test_that("estimate_contrasts - Random Effects Levels, pairwise", {
 
   # Quality of Life score ranges from 0 to 25
   m_null <- glmmTMB::glmmTMB(qol ~ 1 + (1 | gender:employed:age), data = dat)
-  expect_message(
-    estimate_means(m_null, by = c("gender", "employed", "age")),
-    regex = "Standard errors are probably not reliable"
+  expect_silent(
+    estimate_means(m_null, by = c("gender", "employed", "age"))
   )
   expect_silent(
     estimate_means(m_null, by = c("gender", "employed", "age"), verbose = FALSE)


### PR DESCRIPTION
Fixes #526