### PR TITLE
emmeans backend doesn't seem to allow stratification by random factors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.16.0.1
+Version: 0.16.0.2
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@
 
 * Minor bug fix when evaluating `slope` and `by` arguments in `estimate_slopes()`.
 
+* `get_emcontrasts()`, `get_emmeans()` and `get_emtrends()` (i.e., functions
+  using `backend = "emmeans"`) now give an informative error message when
+  `by` or `contrast` refer to a variable that is only used as random effects
+  grouping factor (e.g., `Subject` in `(1 | Subject)`), instead of failing
+  with a cryptic error. Such variables can only be used with
+  `backend = "marginaleffects"`.
+
 # modelbased 0.15.0
 
 ## Breaking Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,8 +38,8 @@
 
 * `get_emcontrasts()`, `get_emmeans()` and `get_emtrends()` (i.e., functions
   using `backend = "emmeans"`) now give an informative error message when
-  `by` or `contrast` refer to a variable that is only used as random effects
-  grouping factor (e.g., `Subject` in `(1 | Subject)`), instead of failing
+  `by`, `contrast`, or `trend` refer to a variable that is only used as random
+  effects grouping factor (e.g., `Subject` in `(1 | Subject)`), instead of failing
   with a cryptic error. Such variables can only be used with
   `backend = "marginaleffects"`.
 

--- a/R/estimate_contrasts.R
+++ b/R/estimate_contrasts.R
@@ -94,7 +94,15 @@
 #' `"hedges.g"`, `"cohens.d.sigma"`, `"r"`, or `"akp.robust.d"`. See `effect.type`
 #' argument of [`bootES::bootES()`] for details. If not specified, defaults to
 #' `"cohens.d"`.
-#' @param iterations The number of bootstrap resamples to perform.
+#' @param iterations This argument has two distinct effects, depending on
+#' context. When `effectsize = "boot"`, it defines the number of bootstrap
+#' resamples used to calculate the effect size (via [bootES::bootES()]), and
+#' defaults to `200` in this case. For Bayesian models estimated with the
+#' `"marginaleffects"` backend, it is passed to the `ndraws` argument of the
+#' related `marginaleffects` functions, and defines the number of posterior
+#' draws to sample from. If `NULL` (the default), all draws are used. Note
+#' that `ndraws` currently only has an effect for Bayesian models fit with
+#' **brms** or **MCMCglmm**.
 #' @inheritParams estimate_means
 #'
 #' @inherit estimate_means details
@@ -452,7 +460,7 @@ estimate_contrasts.default <- function(
   post_process = NULL,
   keep_iterations = FALSE,
   effectsize = NULL,
-  iterations = 200,
+  iterations = NULL,
   es_type = NULL,
   backend = NULL,
   verbose = TRUE,
@@ -503,6 +511,7 @@ estimate_contrasts.default <- function(
       estimate = estimate,
       transform = transform,
       post_process = post_process,
+      iterations = iterations,
       keep_iterations = keep_iterations,
       verbose = verbose,
       ...
@@ -512,12 +521,14 @@ estimate_contrasts.default <- function(
 
   # add effect size ----------------------------------------------------------
   if (!is.null(effectsize)) {
+    # default number of bootstrap resamples, if not specified
+    bootstraps <- if (is.null(iterations)) 200 else iterations
     out <- .estimate_contrasts_effectsize(
       model = model,
       estimated = estimated,
       contrasts_results = out,
       effectsize = effectsize,
-      bootstraps = iterations,
+      bootstraps = bootstraps,
       bootES_type = es_type,
       backend = backend
     )

--- a/R/get_contexteffects.R
+++ b/R/get_contexteffects.R
@@ -8,6 +8,7 @@
   transform = NULL,
   post_process = NULL,
   model_info,
+  iterations = NULL,
   verbose = TRUE,
   ...
 ) {
@@ -51,6 +52,11 @@
       fun_args$type <- predict
       fun_args$transform <- transform
     }
+  }
+
+  # bayesian models: number of posterior draws to use, passed to `ndraws`
+  if (!is.null(iterations)) {
+    fun_args$ndraws <- iterations
   }
 
   out <- do.call(marginaleffects::avg_comparisons, c(fun_args, dots))

--- a/R/get_emmeans.R
+++ b/R/get_emmeans.R
@@ -246,7 +246,9 @@ get_emmeans <- function(
   if (is.null(x)) {
     character(0)
   } else if (is.character(x)) {
-    x
+    # strip "= <values/function>" suffix, e.g. "Subject = c(308, 309)" or
+    # "Subject = [fivenum]", to get the plain variable name
+    trimws(sub("=.*", "", x))
   } else if (inherits(x, "formula")) {
     all.vars(x)
   } else if (is.list(x) || is.data.frame(x)) {

--- a/R/get_emmeans.R
+++ b/R/get_emmeans.R
@@ -238,13 +238,63 @@ get_emmeans <- function(
 
 # Bring arguments in shape for emmeans ----------------------------------------
 
+# extract variable names referenced by "by" / "contrast" / "trend" arguments,
+# regardless of whether these were provided as character, formula, list or
+# data frame
+#' @keywords internal
+.get_emmeans_arg_vars <- function(x) {
+  if (is.null(x)) {
+    character(0)
+  } else if (is.character(x)) {
+    x
+  } else if (inherits(x, "formula")) {
+    all.vars(x)
+  } else if (is.list(x) || is.data.frame(x)) {
+    names(x)
+  } else {
+    character(0)
+  }
+}
+
 #' @keywords internal
 .process_emmeans_arguments <- function(model, args, data, ...) {
   # Create the data_matrix
   # ---------------------------
   # data <- insight::get_data(model, verbose = FALSE)
   predictors <- insight::find_predictors(model, effects = "fixed", flatten = TRUE, ...)
-  data <- data[intersect(predictors, colnames(data))]
+
+  # `by` / `contrast` / `trend` may refer to variables that are not part of
+  # the fixed effects (e.g., random effects grouping factors, see #798).
+  # Make sure these are not dropped from `data`, else `insight::get_datagrid()`
+  # fails to find them later.
+  extra_vars <- unique(c(
+    .get_emmeans_arg_vars(args$by),
+    .get_emmeans_arg_vars(args$contrast),
+    .get_emmeans_arg_vars(args$trend)
+  ))
+
+  # `emmeans` builds its reference grid from the fixed effects part of the
+  # model only. Thus, variables that are exclusively used as random effects
+  # grouping factors (e.g., "Subject" in `(1 | Subject)`) can never be part
+  # of that grid, unlike for the "marginaleffects" backend, which builds the
+  # data grid directly from the data and can therefore handle such variables.
+  # We detect this situation early and give an informative error message
+  # instead of letting this fail downstream with a cryptic error (#798).
+  random_predictors <- setdiff(
+    insight::find_predictors(model, effects = "random", flatten = TRUE, ...),
+    predictors
+  )
+  unsupported <- intersect(extra_vars, random_predictors)
+  if (length(unsupported)) {
+    insight::format_error(paste0(
+      "Variable ",
+      datawizard::text_concatenate(unsupported, enclose = "`"),
+      " only used as random effects grouping factor and cannot be used ",
+      "with `backend = \"emmeans\"`. Please use `backend = \"marginaleffects\"` instead."
+    ))
+  }
+
+  data <- data[intersect(union(predictors, extra_vars), colnames(data))]
 
   # Deal with 'at'
   if (is.null(args$by)) {

--- a/R/get_emmeans.R
+++ b/R/get_emmeans.R
@@ -289,9 +289,13 @@ get_emmeans <- function(
   unsupported <- intersect(extra_vars, random_predictors)
   if (length(unsupported)) {
     insight::format_error(paste0(
-      "Variable ",
+      if (length(unsupported) == 1) "Variable " else "Variables ",
       datawizard::text_concatenate(unsupported, enclose = "`"),
-      " only used as random effects grouping factor and cannot be used ",
+      if (length(unsupported) == 1) {
+        " is only used as a random-effects grouping factor and cannot be used "
+      } else {
+        " are only used as random-effects grouping factors and cannot be used "
+      },
       "with `backend = \"emmeans\"`. Please use `backend = \"marginaleffects\"` instead."
     ))
   }

--- a/R/get_inequalitycontrasts.R
+++ b/R/get_inequalitycontrasts.R
@@ -9,6 +9,7 @@
   ci,
   estimate = NULL,
   post_process = NULL,
+  iterations = NULL,
   verbose = TRUE,
   ...
 ) {
@@ -75,13 +76,15 @@
     # named list, which we need to specify the pairwise-contrasts. However, we
     # can use the hypothesis argument to specify the pairwise contrasts first, and
     # then calculate the marginal effects inequalities in the second step.
-    out <- marginaleffects::avg_slopes(
+    slopes_args <- insight::compact_list(list(
       model = model,
       variables = my_args$contrast,
       by = my_args$by,
       newdata = datagrid,
-      hypothesis = formulas$f1
-    )
+      hypothesis = formulas$f1,
+      ndraws = iterations
+    ))
+    out <- do.call(marginaleffects::avg_slopes, slopes_args)
     out <- marginaleffects::hypotheses(out, hypothesis = formulas$f2)
     # save some labels for printing
     attr(out, "by") <- my_args$by
@@ -111,12 +114,14 @@
 
       formulas <- .inequality_formula(comparison, group)
 
-      out <- marginaleffects::avg_predictions(
+      predictions_args <- insight::compact_list(list(
         model = model,
         variables = c(my_args$contrast, my_args$by),
         newdata = datagrid,
-        hypothesis = formulas$f1
-      )
+        hypothesis = formulas$f1,
+        ndraws = iterations
+      ))
+      out <- do.call(marginaleffects::avg_predictions, predictions_args)
       out <- marginaleffects::hypotheses(out, hypothesis = formulas$f2)
     } else {
       # ----------------------------------------------
@@ -136,7 +141,7 @@
       }
       # for this special case, we need "avg_comparisons()", else we cannot specify
       # the "variables" argument as named list
-      out <- marginaleffects::avg_comparisons(
+      comparisons_args <- insight::compact_list(list(
         model = model,
         variables = as.list(stats::setNames(
           rep_len("pairwise", length(my_args$contrast)),
@@ -145,8 +150,9 @@
         by = my_args$by,
         newdata = datagrid,
         hypothesis = formulas$f2,
-        ...
-      )
+        ndraws = iterations
+      ))
+      out <- do.call(marginaleffects::avg_comparisons, c(comparisons_args, list(...)))
     }
   }
 

--- a/R/get_marginalcontrasts.R
+++ b/R/get_marginalcontrasts.R
@@ -11,6 +11,7 @@ get_marginalcontrasts <- function(
   transform = NULL,
   post_process = NULL,
   p_adjust = "none",
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -88,6 +89,7 @@ get_marginalcontrasts <- function(
       ci,
       estimate,
       post_process = post_process,
+      iterations = iterations,
       verbose = verbose,
       ...
     )
@@ -104,6 +106,7 @@ get_marginalcontrasts <- function(
       transform = transform,
       post_process = post_process,
       model_info = model_info,
+      iterations = iterations,
       verbose = verbose,
       ...
     )
@@ -136,6 +139,7 @@ get_marginalcontrasts <- function(
       backend = "marginaleffects",
       transform = transform,
       post_process = post_process,
+      iterations = iterations,
       keep_iterations = keep_iterations,
       verbose = verbose,
       ...
@@ -153,6 +157,7 @@ get_marginalcontrasts <- function(
       estimate = estimate,
       transform = transform,
       post_process = post_process,
+      iterations = iterations,
       keep_iterations = keep_iterations,
       verbose = verbose,
       .joint_test = my_args$joint_test,
@@ -183,6 +188,7 @@ get_marginalcontrasts <- function(
       p_adjust = p_adjust,
       contrast_filter = my_args$contrast_filter,
       context_effects = my_args$context_effects,
+      iterations = iterations,
       keep_iterations = keep_iterations
     )
   )

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -179,6 +179,9 @@ get_marginalmeans <- function(
   # cleanup
   fun_args <- insight::compact_list(c(fun_args, dots))
 
+  # handle remaining arguments ---------------------------------------
+  # ------------------------------------------------------------------
+
   ## TODO: need to check against different mixed models results from other packages
   # set to NULL
   if (!"re.form" %in% names(dots)) {
@@ -649,8 +652,8 @@ get_marginalmeans <- function(
     "at", "by", "focal_terms", "adjusted_for", "predict", "trend", "comparison",
     "contrast", "estimate", "p_adjust", "transform", "datagrid", "preserve_range",
     "coef_name", "slope", "ci", "model_info", "contrast_filter", "null",
-    "keep_iterations", "joint_test", "omnibus_test", "vcov", "equivalence",
-    "context_effects"
+    "iterations", "keep_iterations", "joint_test", "omnibus_test", "vcov",
+    "equivalence", "context_effects"
   )
 }
 

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -28,6 +28,7 @@ get_marginalmeans <- function(
   ci = 0.95,
   estimate = NULL,
   transform = NULL,
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -198,6 +199,11 @@ get_marginalmeans <- function(
     fun_args$transform <- transform
   }
 
+  # bayesian models: number of posterior draws to use, passed to `ndraws`
+  if (!is.null(iterations)) {
+    fun_args$ndraws <- iterations
+  }
+
   # Fourth step: compute marginal means ---------------------------------------
   # ---------------------------------------------------------------------------
 
@@ -265,6 +271,7 @@ get_marginalmeans <- function(
         estimate = estimate,
         datagrid = datagrid,
         transform = !is.null(transform),
+        iterations = iterations,
         keep_iterations = keep_iterations,
         joint_test = joint_test,
         omnibus_test = omnibus_test,

--- a/R/get_marginaltrends.R
+++ b/R/get_marginaltrends.R
@@ -16,6 +16,7 @@ get_marginaltrends <- function(
   estimate = NULL,
   transform = NULL,
   p_adjust = "none",
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -135,6 +136,11 @@ get_marginaltrends <- function(
     fun_args$vcov <- FALSE
   }
 
+  # bayesian models: number of posterior draws to use, passed to `ndraws`
+  if (!is.null(iterations)) {
+    fun_args$ndraws <- iterations
+  }
+
   # Third step: compute marginal slopes ---------------------------------------
   # ---------------------------------------------------------------------------
 
@@ -191,6 +197,7 @@ get_marginaltrends <- function(
         p_adjust = p_adjust,
         ci = ci,
         transform = !is.null(transform),
+        iterations = iterations,
         keep_iterations = keep_iterations,
         vcov = vcov_slopes,
         equivalence = dots$equivalence

--- a/man/estimate_contrasts.Rd
+++ b/man/estimate_contrasts.Rd
@@ -20,7 +20,7 @@ estimate_contrasts(model, ...)
   post_process = NULL,
   keep_iterations = FALSE,
   effectsize = NULL,
-  iterations = 200,
+  iterations = NULL,
   es_type = NULL,
   backend = NULL,
   verbose = TRUE,
@@ -267,7 +267,15 @@ to the output. You can reshape them to a long format by running
 \code{"emmeans"}, \code{"marginal"}, or \code{"boot"}. Default is \code{NULL}, i.e. no effect
 size will be computed.}
 
-\item{iterations}{The number of bootstrap resamples to perform.}
+\item{iterations}{This argument has two distinct effects, depending on
+context. When \code{effectsize = "boot"}, it defines the number of bootstrap
+resamples used to calculate the effect size (via \code{\link[bootES:bootES]{bootES::bootES()}}), and
+defaults to \code{200} in this case. For Bayesian models estimated with the
+\code{"marginaleffects"} backend, it is passed to the \code{ndraws} argument of the
+related \code{marginaleffects} functions, and defines the number of posterior
+draws to sample from. If \code{NULL} (the default), all draws are used. Note
+that \code{ndraws} currently only has an effect for Bayesian models fit with
+\strong{brms} or \strong{MCMCglmm}.}
 
 \item{es_type}{Specifies the type of effect-size measure to estimate when
 using \code{effectsize = "boot"}. One of \code{"unstandardized"}, \code{"cohens.d"},

--- a/man/get_emmeans.Rd
+++ b/man/get_emmeans.Rd
@@ -52,6 +52,7 @@ get_marginalcontrasts(
   transform = NULL,
   post_process = NULL,
   p_adjust = "none",
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -64,6 +65,7 @@ get_marginalmeans(
   ci = 0.95,
   estimate = NULL,
   transform = NULL,
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -78,6 +80,7 @@ get_marginaltrends(
   estimate = NULL,
   transform = NULL,
   p_adjust = "none",
+  iterations = NULL,
   keep_iterations = FALSE,
   verbose = TRUE,
   ...
@@ -326,6 +329,16 @@ one of \code{"none"} (default), \code{"hochberg"}, \code{"hommel"}, \code{"bonfe
 \code{"BY"}, \code{"fdr"}, \code{"tukey"}, \code{"sidak"}, or \code{"holm"}. \code{"sup-t"} computes
 simultaneous confidence bands, also called sup-t confidence band (Montiel
 Olea & Plagborg-Møller, 2019).}
+
+\item{iterations}{This argument has two distinct effects, depending on
+context. When \code{effectsize = "boot"}, it defines the number of bootstrap
+resamples used to calculate the effect size (via \code{\link[bootES:bootES]{bootES::bootES()}}), and
+defaults to \code{200} in this case. For Bayesian models estimated with the
+\code{"marginaleffects"} backend, it is passed to the \code{ndraws} argument of the
+related \code{marginaleffects} functions, and defines the number of posterior
+draws to sample from. If \code{NULL} (the default), all draws are used. Note
+that \code{ndraws} currently only has an effect for Bayesian models fit with
+\strong{brms} or \strong{MCMCglmm}.}
 }
 \description{
 These functions are convenient wrappers around the \strong{emmeans} and the

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -11,14 +11,28 @@ test_that("estimate_means - brms", {
     Sepal.Length ~ Species * Sepal.Width,
     data = iris,
     refresh = 0,
-    iter = 1000
+    iter = 1000,
+    seed = 123
   )
   estim <- estimate_means(model, backend = "emmeans")
   expect_identical(dim(estim), c(3L, 5L))
+
+  estim1 <- estimate_means(model, backend = "marginaleffects")
+  expect_null(attributes(estim1)$iterations)
+
+  estim2 <- estimate_means(model, iterations = 200, backend = "marginaleffects")
+  expect_identical(attributes(estim2)$iterations, 200)
+
+  expect_true(all(abs(estim1$Median - estim2$Median) > 0.001))
 })
 
 test_that("estimate_relation - brms", {
-  model <- brms::brm(Sepal.Length ~ Species * Sepal.Width, data = iris, refresh = 0, iter = 1000)
+  model <- brms::brm(
+    Sepal.Length ~ Species * Sepal.Width,
+    data = iris,
+    refresh = 0,
+    iter = 1000
+  )
   estim <- estimate_relation(model, preserve_range = FALSE)
   expect_identical(dim(estim), c(30L, 6L))
 
@@ -27,7 +41,12 @@ test_that("estimate_relation - brms", {
 })
 
 test_that("estimate_slopes - brms", {
-  model <- brms::brm(Sepal.Length ~ Species * Sepal.Width, data = iris, refresh = 0, iter = 1000)
+  model <- brms::brm(
+    Sepal.Length ~ Species * Sepal.Width,
+    data = iris,
+    refresh = 0,
+    iter = 1000
+  )
   estim <- estimate_slopes(model, by = "Species", backend = "emmeans")
   expect_identical(dim(estim), c(3L, 5L))
 })
@@ -44,8 +63,16 @@ test_that("estimate_means - brms, multivariate", {
   expect_named(
     estim,
     c(
-      "wt", "ROPE_CI", "Response", "Median", "CI_low", "CI_high",
-      "pd", "ROPE_low", "ROPE_high", "ROPE_Percentage"
+      "wt",
+      "ROPE_CI",
+      "Response",
+      "Median",
+      "CI_low",
+      "CI_high",
+      "pd",
+      "ROPE_low",
+      "ROPE_high",
+      "ROPE_Percentage"
     )
   )
 })

--- a/tests/testthat/test-estimate_means.R
+++ b/tests/testthat/test-estimate_means.R
@@ -711,3 +711,25 @@ test_that("estimate_means, coxph-survival", {
   expect_named(emm, c("hormon", "Mean", "SE", "CI_low", "CI_high", "z"))
   expect_equal(emm$Mean, c(0.82661, 1.15039), tolerance = 1e-4)
 })
+
+
+test_that("estimate_means, backend emmeans, errors when predicting RE", {
+  skip_if_not_installed("lme4")
+  data(mtcars)
+  m1 <- lme4::lmer(mpg ~ hp + (1 | carb), data = mtcars)
+  expect_error(
+    estimate_means(m1, "carb", backend = "emmeans"),
+    regex = "Variable `carb` only used",
+    fixed = TRUE
+  )
+  expect_error(
+    estimate_means(m1, "carb=c(2,4)", backend = "emmeans"),
+    regex = "Variable `carb` only used",
+    fixed = TRUE
+  )
+  expect_error(
+    estimate_means(m1, c("hp", "carb"), backend = "emmeans"),
+    regex = "Variable `carb` only used",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-estimate_means.R
+++ b/tests/testthat/test-estimate_means.R
@@ -719,17 +719,33 @@ test_that("estimate_means, backend emmeans, errors when predicting RE", {
   m1 <- lme4::lmer(mpg ~ hp + (1 | carb), data = mtcars)
   expect_error(
     estimate_means(m1, "carb", backend = "emmeans"),
-    regex = "Variable `carb` only used",
+    regex = "Variable `carb` is only used",
     fixed = TRUE
   )
   expect_error(
     estimate_means(m1, "carb=c(2,4)", backend = "emmeans"),
-    regex = "Variable `carb` only used",
+    regex = "Variable `carb` is only used",
     fixed = TRUE
   )
   expect_error(
     estimate_means(m1, c("hp", "carb"), backend = "emmeans"),
-    regex = "Variable `carb` only used",
+    regex = "Variable `carb` is only used",
+    fixed = TRUE
+  )
+  m1 <- lme4::lmer(mpg ~ hp + (1 | carb) + (1 | cyl), data = mtcars)
+  expect_error(
+    estimate_means(m1, c("carb", "cyl"), backend = "emmeans"),
+    regex = "Variables `carb` and `cyl` are only",
+    fixed = TRUE
+  )
+  expect_error(
+    estimate_means(m1, c("carb=c(2,4)", "cyl"), backend = "emmeans"),
+    regex = "Variables `carb` and `cyl` are only",
+    fixed = TRUE
+  )
+  expect_error(
+    estimate_means(m1, c("hp", "carb", "cyl"), backend = "emmeans"),
+    regex = "Variables `carb` and `cyl` are only",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
``` r
library(modelbased)

dat <- lme4::sleepstudy
dat$Condition <- ifelse(dat$Days < median(dat$Days), "Low", "High")
m <- lme4::lmer(Reaction ~ Condition + (Condition | Subject), data = dat)

get_marginalcontrasts(m, contrast = "Condition", by = "Subject")
#>         Parameter Subject Difference       SE     CI_low    CI_high           t
#> 1  (Low) - (High)     308 -96.163212 8.620562 -113.17754 -79.148883 -11.1550981
#> 2  (Low) - (High)     309  -9.114864 8.620562  -26.12919   7.899465  -1.0573400
#> 3  (Low) - (High)     310 -20.485587 8.620562  -37.49992  -3.471258  -2.3763633
...


get_emcontrasts(m, contrast = "Condition", by = "Subject")
#> Error:
#> ! Variable `Subject` only used as random effects grouping factor and
#>   cannot be used with `backend = "emmeans"`. Please use `backend =
#>   "marginaleffects"` instead.
```

<sup>Created on 2026-07-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

So instead we throw a more informative error.

Unless @mattansb you are aware of some hidden backdoor to emmeans to get that (ai says *recover_data() deliberately keeps only the fixed-effects predictors in the reference grid. Grouping variables used solely for random effects are discarded.*). 