### PR TITLE
Post-processing no longer prints redundant labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: modelbased
 Title: Estimation of Model-Based Predictions, Contrasts and Means
-Version: 0.17.0.3
+Version: 0.17.0.4
 Authors@R:
     c(person(given = "Dominique",
              family = "Makowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Changes
 
+* Post-processing in `estimate_contrasts()` including group-variable (e.g.,
+  `post_process = ~ pairwise | group_var`) now no longer prints levels from
+  `group_var`in both the group and comparison columns (i.e. redundant labels
+  have been removed from the output).
+
 * `estimate_contrasts()` with custom comparisons (e.g., when
   `comparison = "(b1 - b12) = (b4 - b18)"`) can yield incorrect results when
   `estimate = "average"` and predictions are filtered (e.g. when

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Post-processing in `estimate_contrasts()` including group-variable (e.g.,
   `post_process = ~ pairwise | group_var`) now no longer prints levels from
-  `group_var`in both the group and comparison columns (i.e. redundant labels
+  `group_var` in both the group and comparison columns (i.e. redundant labels
   have been removed from the output).
 
 * `estimate_contrasts()` with custom comparisons (e.g., when

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -375,7 +375,12 @@ get_marginalmeans <- function(
         out,
         hypothesis = post_process[[i]]
       ))
-      temp_params <- .update_post_process_params(out, temp_params, group_params)
+      temp_params <- .update_post_process_params(
+        out,
+        temp_params,
+        group_params,
+        post_process[[i]]
+      )
     }
     # check if extractinb parameters worked
     if (length(temp_params) == nrow(out)) {
@@ -385,10 +390,42 @@ get_marginalmeans <- function(
   out
 }
 
-.update_post_process_params <- function(out, temp_params, group_params) {
+.update_post_process_params <- function(
+  out,
+  temp_params,
+  group_params,
+  post_process = NULL
+) {
   if (is.null(temp_params)) {
     return(NULL)
   }
+
+  # we may have groups in post-processing contrasts, and these groups should not
+  # be included in the levels of the hypothesis
+  if (!is.null(post_process)) {
+    # extract all group variables from post-processing hypothesis, i.e.
+    # extract "groups" from "difference ~ pairwise | groups"
+    comparison_groups <- vapply(
+      unlist(
+        strsplit(insight::safe_deparse(post_process), "|", fixed = TRUE),
+        use.names = FALSE
+      ),
+      insight::trim_ws,
+      character(1)
+    )
+    # if we have any groups, check if these names also appear in the group-name
+    # data frame, and if yes, remove them. these groups have their own column
+    # in the output and don't need to appear twice (in the comparison labels)
+    # again
+    if (length(comparison_groups) > 1) {
+      comparison_groups <- all.vars(stats::formula(paste("~", comparison_groups[2])))
+      remove <- intersect(colnames(group_params), comparison_groups)
+      if (length(remove)) {
+        group_params[remove] <- NULL
+      }
+    }
+  }
+
   .safe(
     {
       # clean current parameter names

--- a/R/get_marginalmeans.R
+++ b/R/get_marginalmeans.R
@@ -402,14 +402,18 @@ get_marginalmeans <- function(
 
   # we may have groups in post-processing contrasts, and these groups should not
   # be included in the levels of the hypothesis
-  if (!is.null(post_process)) {
+  if (
+    !is.null(post_process) &&
+      (inherits(post_process, "formula") || is.character(post_process))
+  ) {
     # extract all group variables from post-processing hypothesis, i.e.
     # extract "groups" from "difference ~ pairwise | groups"
     comparison_groups <- vapply(
-      unlist(
-        strsplit(insight::safe_deparse(post_process), "|", fixed = TRUE),
-        use.names = FALSE
-      ),
+      strsplit(
+        paste(insight::safe_deparse(post_process), collapse = ""),
+        "|",
+        fixed = TRUE
+      )[[1L]],
       insight::trim_ws,
       character(1)
     )

--- a/tests/testthat/test-estimate_contrasts.R
+++ b/tests/testthat/test-estimate_contrasts.R
@@ -1942,3 +1942,35 @@ test_that("estimate_contrast, correctly preserve minus in factor levels", {
     c("A - High", "A - High", "A - Low", "A - High", "A - Low", "B - High")
   )
 })
+
+
+test_that("estimate_contrast, don't let group labels appear in comparison labels", {
+  data(efc, package = "modelbased")
+  efc <- datawizard::to_factor(efc, c("c161sex", "c172code", "e16sex", "e42dep"))
+  levels(efc$c172code) <- c("low", "mid", "high")
+  m <- lm(neg_c_7 ~ barthtot + c172code * e42dep * c161sex, data = efc)
+
+  out <- estimate_contrasts(
+    m,
+    "c161sex",
+    by = c("c172code", "e42dep"),
+    estimate = "average",
+    post_process = ~ pairwise | e42dep
+  )
+  expect_identical(dim(out), c(10L, 8L))
+  expect_identical(
+    out$Parameter,
+    c(
+      "Female - Male, mid - low",
+      "Female - Male, mid - low",
+      "Female - Male, high - low",
+      "Female - Male, high - mid",
+      "Female - Male, mid - low",
+      "Female - Male, high - low",
+      "Female - Male, high - mid",
+      "Female - Male, mid - low",
+      "Female - Male, high - low",
+      "Female - Male, high - mid"
+    )
+  )
+})


### PR DESCRIPTION
This code

```r
  data(efc, package = "modelbased")
  efc <- datawizard::to_factor(efc, c("c161sex", "c172code", "e16sex", "e42dep"))
  levels(efc$c172code) <- c("low", "mid", "high")
  m <- lm(neg_c_7 ~ barthtot + c172code * e42dep * c161sex, data = efc)

  out <- estimate_contrasts(
    m,
    "c161sex",
    by = c("c172code", "e42dep"),
    estimate = "average",
    post_process = ~ pairwise | e42dep
  )
```

used to include levels from the grouping-variable `e42dep` in the `Parameters` column, where the levels of comparisons were saved (i.e. the levels of `e42dep` appeared in two columns). This redundant information is now removed, to clean the output.